### PR TITLE
Unnecessary Ternary operator removed

### DIFF
--- a/addon/src/SyntaxHighlighter.js
+++ b/addon/src/SyntaxHighlighter.js
@@ -76,7 +76,11 @@ export default class SyntaxHighlighter extends Component {
       ...rest
     } = this.props;
     const { copied } = this.state;
-    return children ? (
+    if(!children){
+      return null
+    }
+
+    return (
       <>
         <ScrollArea vertical>
           <ReactSyntaxHighlighter
@@ -93,14 +97,13 @@ export default class SyntaxHighlighter extends Component {
             {children.trim()}
           </ReactSyntaxHighlighter>
         </ScrollArea>
-        {copyable ? (
+        { copyable && 
           <ActionBar
             actionItems={[
               { title: copied ? 'Copied' : 'Copy', onClick: this.onClick },
             ]}
-          />
-        ) : null}
+          />}
       </>
-    ) : null;
+    )
   }
 }


### PR DESCRIPTION
Hey 
According to airbnb javascript  guidelines [this](https://airbnb.io/javascript/#comparison--unneeded-ternary) 
We should remove unnecessary ternary operators 
So in this PR i have removed those which i feel are not important.
Have a look..