### PR TITLE
Remove Lit HTML comments by adjusting regex #64

### DIFF
--- a/addon/src/decorators/withHTML.js
+++ b/addon/src/decorators/withHTML.js
@@ -12,7 +12,7 @@ export const withHTML = makeDecorator({
       const root = document.querySelector(rootSelector);
       let html = root ? root.innerHTML : `${rootSelector} not found.`;
       if (parameters.removeEmptyComments) {
-        html = html.replace(/<!--\s*-->/g, '');
+        html = html.replace(/<!--.*-->/g, '');
       }
       channel.emit(EVENT_CODE_RECEIVED, { html, options: parameters });
     }, 0);


### PR DESCRIPTION
This PR adjusts the regex so all HTML comments will be replaced.

<img width="687" alt="Screenshot 2022-01-19 at 00 58 26" src="https://user-images.githubusercontent.com/1086961/150038016-0a0f9b08-e815-4c28-be09-ea012fea4970.png">