### PR TITLE
Adds parameter to override default timeout when searching for the rootSelector element

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ export const parameters = {
 };
 ```
 
+You can override the default timeout value to ensure the DOM is completely loaded before searching for the wrapper selector element.
+
+```js
+export const parameters = {
+  html: {
+    delay: 500, // default: 0
+  },
+};
+```
+
 When using Web Components, the HTML will contain empty comments, i.e. `<!---->`.
 If you want to remove these, use the `removeEmptyComments` parameter:
 

--- a/addon/src/decorators/withHTML.js
+++ b/addon/src/decorators/withHTML.js
@@ -15,7 +15,7 @@ export const withHTML = makeDecorator({
         html = html.replace(/<!--\s*-->/g, '');
       }
       channel.emit(EVENT_CODE_RECEIVED, { html, options: parameters });
-    }, 500);
+    }, parameters.delay || 0);
     return storyFn(context);
   },
 });

--- a/addon/src/decorators/withHTML.js
+++ b/addon/src/decorators/withHTML.js
@@ -15,7 +15,7 @@ export const withHTML = makeDecorator({
         html = html.replace(/<!--\s*-->/g, '');
       }
       channel.emit(EVENT_CODE_RECEIVED, { html, options: parameters });
-    }, 0);
+    }, 500);
     return storyFn(context);
   },
 });


### PR DESCRIPTION
When at 0 seconds, the "root" variable is undefined. Adding a delay allows the page to render before searching for the rootSelector element.