### PR TITLE
fix: invalid package.json on Vue example

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Example of a Storybook app using @whitespace/storybook-addon-html with Vue",
   "private": true,
-  "license": "AGPL"
+  "license": "AGPL",
   "scripts": {
     "start": "start-storybook -p 6006",
     "build": "build-storybook",


### PR DESCRIPTION
The missing `,` make that `yarn install` breaks