### PR TITLE
feat: add `removeComments` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,23 @@ export const parameters = {
 };
 ```
 
-When using Web Components, the HTML will contain empty comments, i.e. `<!---->`.
-If you want to remove these, use the `removeEmptyComments` parameter:
+When using Web Components, the HTML will contain empty comments, i.e. `<!---->`, or `<!--..lit$..-->` if using [lit-html](https://lit.dev/docs/). If you want to remove these, use the `removeComments` parameter:
 
 ```js
 export const parameters = {
   html: {
-    removeEmptyComments: true, // default: false
+    removeComments: true, // default: false
+  },
+};
+```
+
+you can also provide your own regular expression to remove specific HTML comments:
+
+```js
+export const parameters = {
+  html: {
+    // Remove only lit HTML comments, eg: `<!--?lit$117057236$-->`
+    removeComments: /<!--(.lit.*?)-->/g, 
   },
 };
 ```

--- a/addon/src/decorators/withHTML.js
+++ b/addon/src/decorators/withHTML.js
@@ -1,6 +1,15 @@
 import { addons, makeDecorator } from '@storybook/addons';
 import { EVENT_CODE_RECEIVED } from '../shared';
 
+const isValidRegExp = (expression) => {
+  try {
+    new RegExp(expression);
+  } catch (e) {
+    throw new Error(e.message);
+  }
+  return true;
+};
+
 export const withHTML = makeDecorator({
   name: 'withHTML',
   parameterName: 'html',
@@ -13,6 +22,16 @@ export const withHTML = makeDecorator({
       let html = root ? root.innerHTML : `${rootSelector} not found.`;
       if (parameters.removeEmptyComments) {
         html = html.replace(/<!--\s*-->/g, '');
+      }
+      if (parameters.removeComments) {
+        const { removeComments } = parameters;
+        if (typeof removeComments === 'boolean') {
+          // Will remove all HTML comments
+          html = html.replace(/<!--(.*?)-->/g, '');
+        } else if (isValidRegExp(removeComments)) {
+          // Will remove only HTML comments matching the expression provided
+          html = html.replace(removeComments, '');
+        }
       }
       channel.emit(EVENT_CODE_RECEIVED, { html, options: parameters });
     }, 0);

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Example of a Storybook app using @whitespace/storybook-addon-html with Vue",
   "private": true,
-  "license": "AGPL"
+  "license": "AGPL",
   "scripts": {
     "start": "start-storybook -p 6006",
     "build": "build-storybook",

--- a/examples/web-components/.storybook/preview.js
+++ b/examples/web-components/.storybook/preview.js
@@ -2,6 +2,6 @@ export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   html: {
     root: '#root-inner',
-    removeEmptyComments: true,
+    removeComments: true,
   },
 };


### PR DESCRIPTION
The `removeComments` parameter will remove all the HTML comments (if set to `true`) or only the want matching a regular expression provided. Eg:

```js
export const parameters = {
  html: {
    removeComments: true, // default: false
  },
};
```

```js
export const parameters = {
  html: {
    // Remove only lit HTML comments, eg: `<!--?lit$117057236$-->`
    removeComments: /<!--(.lit.*?)-->/g, 
  },
};
```

This change will complement a previous PR #66 created before.
