### PR TITLE
feat: add `paramKey` property to panel object.

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,5 +1,5 @@
 import { addons, types } from "@storybook/manager-api";
-import { ADDON_ID, PANEL_ID } from "./constants";
+import { ADDON_ID, PANEL_ID, PARAM_KEY } from "./constants";
 import { Panel } from "./Panel";
 
 // Register the addon
@@ -10,5 +10,6 @@ addons.register(ADDON_ID, () => {
     title: "HTML",
     match: ({ viewMode }) => viewMode === "story",
     render: Panel,
+    paramKey: PARAM_KEY,
   });
 });


### PR DESCRIPTION
### Description
Add the `paramKey` property when registering the pannel.
This allows users to disable the add-on per a story file or globally.

### example
```
// preview.js
parameters : {
   html: {
      disable: true, // disable HTML pannel.
   }
}
```

### reference 
- https://storybook.js.org/docs/addons/addon-knowledge-base#disable-the-addon-panel

### related
#27 
#105 