### PR TITLE
fix: update syntax-highlighter language option and correct type.

### DIFF
--- a/src/components/PanelContent.tsx
+++ b/src/components/PanelContent.tsx
@@ -14,7 +14,7 @@ export const PanelContent: React.FC<PanelContentProps> = ({
   wrapLines = false,
 }) => (
   <SyntaxHighlighter
-    language={"html"}
+    language={"xml"}
     copyable={true}
     padded={true}
     style={style}

--- a/src/components/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter.tsx
@@ -7,7 +7,9 @@ import {
   SyntaxHighlighterProps,
 } from "@storybook/components";
 
-import ReactSyntaxHighlighter from "react-syntax-highlighter";
+import ReactSyntaxHighlighter, {
+  SyntaxHighlighterProps as ReactSyntaxHighlighterProps,
+} from "react-syntax-highlighter";
 
 type PreProps = {
   padded?: boolean;
@@ -54,7 +56,11 @@ export default function SyntaxHighlighter({
   wrapLines = true,
   renderer,
   ...rest
-}: SyntaxHighlighterProps & { wrapLines?: boolean; children?: string }) {
+}: Omit<SyntaxHighlighterProps, "language"> & {
+  wrapLines?: boolean;
+  children?: string;
+  language?: ReactSyntaxHighlighterProps["language"];
+}) {
   const [copied, setCopied] = useState(false);
 
   const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {


### PR DESCRIPTION
### Replace Unsupported Language Option 'html' with 'xml'
- "html" is not supported by react-syntax-highlighter.
- Replaced by referencing the [previous version settings](https://github.com/whitespace-se/storybook-addon-html/blob/v5.1.4/src/components/PanelContent.js)

### Correct 'language' property type.
  - Storybook's `SyntaxHighlighterProps`'s language props is incompatible with the `ReactSyntaxHighlighter`'s language props.
  - Compare the [supported language list of React-Syntax-Highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD) with the [supported language list of Storybook Syntax Highlighter Props](https://github.com/storybookjs/storybook/blob/7c433480c160c383c2cdeddac0d378368ed7e05c/code/ui/components/src/components/syntaxhighlighter/syntaxhighlighter.tsx#L37)

### related
#119 