### PR TITLE
feat: implement CSS extraction and enhance Panel component for CSS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build-storybook.log
 .DS_Store
 .env
 .eslintcache
+
+.github/skills/
+.github/copilot-instructions.md

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,6 +8,11 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    html: {
+      css: {
+        enabled: true,
+      },
+    },
   },
   initialGlobals: {
     background: { value: 'light' },

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { AddonPanel, SyntaxHighlighter } from 'storybook/internal/components';
 import { useAddonState, useChannel, useParameter } from 'storybook/manager-api';
 import { ADDON_ID, EVENTS, PARAM_KEY } from '../constants';
@@ -8,8 +8,12 @@ interface PanelProps {
   active?: boolean;
 }
 
+type ViewMode = 'html' | 'css' | 'combined';
+
 interface PanelState {
   code: string;
+  css: string;
+  viewMode: ViewMode;
 }
 
 const DEFAULT_PARAMETERS: Parameters = {
@@ -19,32 +23,107 @@ const DEFAULT_PARAMETERS: Parameters = {
   },
 };
 
+function getCombinedCode(html: string, css: string): string {
+  if (!css.trim()) return html;
+  return `<style>\n${css}</style>\n\n${html}`;
+}
+
+const tabBarStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 0,
+  borderBottom: '1px solid var(--color-border-muted-default, #e0e0e0)',
+  padding: '0 8px',
+  backgroundColor: 'var(--color-bg-base, transparent)',
+};
+
+const tabBaseStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  fontSize: '12px',
+  fontWeight: 600,
+  color: 'var(--color-text-muted-default, #666)',
+  borderBottom: '2px solid transparent',
+  marginBottom: '-1px',
+};
+
+const tabActiveStyleOverrides: React.CSSProperties = {
+  color: 'var(--color-text-primary-default, #029cfd)',
+  borderBottomColor: 'var(--color-text-primary-default, #029cfd)',
+};
+
 export const Panel = memo(function Panel({ active = false }: PanelProps) {
-  const [{ code }, setState] = useAddonState<PanelState>(ADDON_ID, {
+  const [state, setState] = useAddonState<PanelState>(ADDON_ID, {
     code: '',
+    css: '',
+    viewMode: 'html',
   });
 
+  const { code, css, viewMode } = state;
+
   useChannel({
-    [EVENTS.CODE_UPDATE]: ({ code: nextCode }: CodeUpdatePayload) => {
-      setState((state) => ({ ...state, code: nextCode }));
+    [EVENTS.CODE_UPDATE]: ({ code: nextCode, css: nextCss }: CodeUpdatePayload) => {
+      setState((prev) => ({
+        ...prev,
+        code: nextCode,
+        css: nextCss || '',
+      }));
     },
   });
 
   const parameters = useParameter<Parameters>(PARAM_KEY, DEFAULT_PARAMETERS);
   const { highlighter: { showLineNumbers = false, wrapLines = true } = {} } = parameters;
+  const cssEnabled = parameters.css?.enabled === true;
+
+  const setViewMode = useCallback(
+    (mode: ViewMode) => {
+      setState((prev) => ({ ...prev, viewMode: mode }));
+    },
+    [setState],
+  );
+
+  const displayCode = useMemo(() => {
+    switch (viewMode) {
+      case 'css':
+        return css || '/* No CSS extracted */';
+      case 'combined':
+        return getCombinedCode(code, css);
+      default:
+        return code;
+    }
+  }, [viewMode, code, css]);
+
+  const language = viewMode === 'css' ? 'css' : 'html';
 
   return (
     <AddonPanel active={active}>
-      <SyntaxHighlighter
-        language="html"
-        copyable
-        padded
-        format={false}
-        showLineNumbers={showLineNumbers}
-        wrapLongLines={wrapLines}
-      >
-        {code}
-      </SyntaxHighlighter>
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {cssEnabled && (
+          <div style={tabBarStyle}>
+            {(['html', 'css', 'combined'] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setViewMode(tab)}
+                style={viewMode === tab ? { ...tabBaseStyle, ...tabActiveStyleOverrides } : tabBaseStyle}
+              >
+                {tab.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        )}
+        <SyntaxHighlighter
+          language={language}
+          copyable
+          padded
+          format={false}
+          showLineNumbers={showLineNumbers}
+          wrapLongLines={wrapLines}
+        >
+          {displayCode}
+        </SyntaxHighlighter>
+      </div>
     </AddonPanel>
   );
 });

--- a/src/css-extractor.ts
+++ b/src/css-extractor.ts
@@ -1,0 +1,179 @@
+import type { CSSParameters } from './types';
+
+const DEFAULT_CSS_OPTIONS: Required<
+  Pick<
+    CSSParameters,
+    'includeCustomProperties' | 'includeMediaQueries' | 'includeFontFace' | 'includeKeyframes' | 'includeLayerRules'
+  >
+> = {
+  includeCustomProperties: false,
+  includeMediaQueries: true,
+  includeFontFace: false,
+  includeKeyframes: false,
+  includeLayerRules: true,
+};
+
+/**
+ * Check if any element in the subtree (or root itself) matches at least one
+ * of the comma-separated selectors in `selectorText`.
+ */
+function elementMatchesSelector(root: Element, selectorText: string): boolean {
+  try {
+    return selectorText.split(',').some((sel) => {
+      const trimmed = sel.trim();
+      return root.matches(trimmed) || root.querySelector(trimmed) !== null;
+    });
+  } catch {
+    // Invalid selector — skip
+    return false;
+  }
+}
+
+/**
+ * Returns true if the rule is a `:root` / `*` custom-property declaration block
+ * (i.e. only contains `--*` properties).
+ */
+function isCustomPropertyRule(rule: CSSStyleRule): boolean {
+  const selector = rule.selectorText.trim();
+  if (selector !== ':root' && selector !== '*') return false;
+  for (let i = 0; i < rule.style.length; i++) {
+    const prop = rule.style.item(i);
+    if (!prop.startsWith('--')) return false;
+  }
+  return rule.style.length > 0;
+}
+
+/**
+ * Extract matching rules from a CSSMediaRule.
+ */
+function extractMediaRuleMatches(root: Element, rule: CSSMediaRule): string[] {
+  const nested: string[] = [];
+  for (const child of Array.from(rule.cssRules)) {
+    if (child instanceof CSSStyleRule) {
+      if (elementMatchesSelector(root, child.selectorText)) {
+        nested.push(child.cssText);
+      }
+    }
+  }
+  return nested;
+}
+
+/**
+ * Extract matching rules from a CSSLayerBlockRule.
+ */
+function extractLayerRuleMatches(
+  root: Element,
+  rule: CSSLayerBlockRule,
+  options: Required<Pick<CSSParameters, 'includeCustomProperties' | 'includeMediaQueries'>>,
+): string[] {
+  const nested: string[] = [];
+  for (const child of Array.from(rule.cssRules)) {
+    if (child instanceof CSSStyleRule) {
+      if (isCustomPropertyRule(child)) {
+        if (options.includeCustomProperties) {
+          nested.push(child.cssText);
+        }
+        continue;
+      }
+      if (elementMatchesSelector(root, child.selectorText)) {
+        nested.push(child.cssText);
+      }
+    } else if (child instanceof CSSMediaRule && options.includeMediaQueries) {
+      const mediaMatches = extractMediaRuleMatches(root, child);
+      if (mediaMatches.length > 0) {
+        nested.push(`@media ${child.conditionText} {\n${mediaMatches.join('\n')}\n}`);
+      }
+    }
+  }
+  return nested;
+}
+
+/**
+ * Check if a CSSKeyframesRule's name is referenced by any animation property
+ * on elements in the story root.
+ */
+function isKeyframesUsed(root: Element, rule: CSSKeyframesRule): boolean {
+  const name = rule.name;
+  const elements = [root, ...Array.from(root.querySelectorAll('*'))];
+  return elements.some((el) => {
+    const style = window.getComputedStyle(el);
+    return style.animationName.split(',').some((n) => n.trim() === name);
+  });
+}
+
+/**
+ * Extract CSS rules that apply to elements within `root`.
+ *
+ * Uses the browser's CSSOM API (`document.styleSheets`) to iterate all
+ * loaded stylesheets and match selectors against the story's rendered DOM.
+ */
+export function extractCSS(root: Element, cssParams: CSSParameters): string {
+  const opts = { ...DEFAULT_CSS_OPTIONS, ...cssParams };
+  const matchingRules: string[] = [];
+  const seen = new Set<string>();
+
+  function addRule(cssText: string): void {
+    if (!seen.has(cssText)) {
+      seen.add(cssText);
+      matchingRules.push(cssText);
+    }
+  }
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      // Cross-origin stylesheet — skip
+      continue;
+    }
+
+    for (const rule of Array.from(rules)) {
+      if (rule instanceof CSSStyleRule) {
+        if (isCustomPropertyRule(rule)) {
+          if (opts.includeCustomProperties) {
+            addRule(rule.cssText);
+          }
+          continue;
+        }
+
+        if (elementMatchesSelector(root, rule.selectorText)) {
+          addRule(rule.cssText);
+        }
+      } else if (rule instanceof CSSMediaRule && opts.includeMediaQueries) {
+        const nestedMatches = extractMediaRuleMatches(root, rule);
+        if (nestedMatches.length > 0) {
+          addRule(`@media ${rule.conditionText} {\n${nestedMatches.join('\n')}\n}`);
+        }
+      } else if (rule instanceof CSSLayerBlockRule && opts.includeLayerRules) {
+        const nestedMatches = extractLayerRuleMatches(root, rule, {
+          includeCustomProperties: opts.includeCustomProperties,
+          includeMediaQueries: opts.includeMediaQueries,
+        });
+        if (nestedMatches.length > 0) {
+          addRule(`@layer ${rule.name} {\n${nestedMatches.join('\n')}\n}`);
+        }
+      } else if (rule instanceof CSSKeyframesRule && opts.includeKeyframes) {
+        if (isKeyframesUsed(root, rule)) {
+          addRule(rule.cssText);
+        }
+      } else if (rule instanceof CSSFontFaceRule && opts.includeFontFace) {
+        // Include all @font-face rules when enabled — a more targeted approach
+        // would check font-family usage, but that requires deep computed-style checks.
+        addRule(rule.cssText);
+      }
+    }
+  }
+
+  let css = matchingRules.join('\n\n');
+
+  if (typeof cssParams.transform === 'function') {
+    try {
+      css = cssParams.transform(css);
+    } catch (error) {
+      console.error('CSS transform failed:', error);
+    }
+  }
+
+  return css;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,14 @@
+export interface CSSParameters {
+  enabled?: boolean;
+  includeCustomProperties?: boolean;
+  includeMediaQueries?: boolean;
+  includeFontFace?: boolean;
+  includeKeyframes?: boolean;
+  includeLayerRules?: boolean;
+  scoping?: string | false;
+  transform?: (css: string) => string;
+}
+
 export interface Parameters {
   disable?: boolean;
   highlighter?: {
@@ -8,9 +19,11 @@ export interface Parameters {
   removeEmptyComments?: boolean;
   removeComments?: boolean | RegExp;
   transform?: (code: string) => string;
+  css?: CSSParameters;
 }
 
 export interface CodeUpdatePayload {
   code: string;
+  css: string;
   options: Parameters;
 }

--- a/src/withHTML.ts
+++ b/src/withHTML.ts
@@ -2,7 +2,9 @@ import { useChannel, useEffect } from 'storybook/preview-api';
 import type { DecoratorFunction } from 'storybook/internal/types';
 import { format as formatWithPrettier } from 'prettier/standalone';
 import htmlPlugin from 'prettier/plugins/html';
+import cssPlugin from 'prettier/plugins/postcss';
 import { EVENTS } from './constants';
+import { extractCSS } from './css-extractor';
 import type { Parameters } from './types';
 
 const DEFAULT_ROOT_SELECTOR = '#storybook-root, #root';
@@ -60,6 +62,19 @@ async function prettifyHtml(code: string) {
   }
 }
 
+async function prettifyCss(code: string) {
+  if (!code.trim()) return '';
+  try {
+    return await formatWithPrettier(code, {
+      parser: 'css',
+      plugins: [cssPlugin],
+    });
+  } catch (error) {
+    console.error('Failed to format CSS with Prettier', error);
+    return code;
+  }
+}
+
 export const withHTML: DecoratorFunction = (storyFn, context) => {
   const emit = useChannel({});
   const parameters = (context.parameters?.html as Parameters | undefined) || {};
@@ -68,7 +83,18 @@ export const withHTML: DecoratorFunction = (storyFn, context) => {
     const timer = window.setTimeout(async () => {
       const code = getCode(context.canvasElement as ParentNode | undefined, parameters);
       const prettifiedCode = await prettifyHtml(code);
-      emit(EVENTS.CODE_UPDATE, { code: prettifiedCode, options: parameters });
+
+      let css = '';
+      if (parameters.css?.enabled) {
+        const rootSelector = parameters.root || DEFAULT_ROOT_SELECTOR;
+        const root = getRootElement(context.canvasElement as ParentNode | undefined, rootSelector);
+        if (root) {
+          const rawCss = extractCSS(root, parameters.css);
+          css = await prettifyCss(rawCss);
+        }
+      }
+
+      emit(EVENTS.CODE_UPDATE, { code: prettifiedCode, css, options: parameters });
     }, 0);
 
     return () => {


### PR DESCRIPTION
## feat: implement CSS extraction and enhance Panel component for CSS support

### Summary

Adds an opt-in CSS extraction capability to the addon. When enabled, the panel extracts CSS rules that apply to a story's rendered HTML using the browser's CSSOM API and displays a self-contained HTML + CSS snippet — ready to paste into any context (email, CMS, documentation, design handoff) without needing the original framework or build tooling.

### Motivation

Currently the addon extracts rendered HTML only. But the HTML relies on CSS that is injected by framework build tools (Vite, webpack), spread across `<style>` tags and `<link>` stylesheets, and often uses CSS Modules, CSS-in-JS, or utility classes. Without the matching CSS, the extracted HTML is unstyled and not useful as a standalone snippet.

### What's new

**CSS Extraction Engine** (`src/css-extractor.ts`)

- Iterates `document.styleSheets` in the preview iframe and matches selectors against the story's rendered DOM
- Handles `CSSStyleRule`, `@media`, `@layer`, `@keyframes`, and `@font-face`
- Splits and individually checks comma-separated selectors
- Gracefully skips cross-origin stylesheets (try/catch)
- Deduplicates rules to avoid emitting the same rule twice
- Supports an optional `transform` callback for custom CSS post-processing

**Panel UI** (`src/components/Panel.tsx`)

- Adds **HTML / CSS / COMBINED** tab switcher (only visible when CSS extraction is enabled)
- COMBINED view wraps CSS in a `<style>` block above the HTML for a copy-paste-ready snippet
- Syntax highlighting switches between `html` and `css` languages based on the active tab

**Configuration** (`src/types.ts`)

Can be set per-story, per-component, or **globally** in `.storybook/preview.ts`. Storybook parameters cascade from global → component → story level, so enabling it globally means all stories get CSS extraction by default, while individual stories can still override with `css: { enabled: false }`.

**Per-story / per-component:**

```ts
parameters: {
  html: {
    css: {
      enabled: true,                  // opt-in (default: false)
      includeCustomProperties: false, // include :root/* CSS custom properties
      includeMediaQueries: true,      // include @media rules
      includeLayerRules: true,        // include @layer rules
      includeFontFace: false,         // include @font-face rules
      includeKeyframes: false,        // include @keyframes rules
      transform: (css) => css,        // custom CSS transform
    },
  },
},
```

**Globally** (in `.storybook/preview.ts`):

```ts
const preview: Preview = {
  parameters: {
    html: {
      css: {
        enabled: true,
      },
    },
  },
};
```

### Breaking changes

**_None_**. CSS extraction is **opt-in** (`css.enabled` defaults to `false`). The existing `parameters.html` API is fully backward-compatible. Stories without `css.enabled` see the same panel as before.

### Files changed

| File                       | Change                                                                                      |
| -------------------------- | ------------------------------------------------------------------------------------------- |
| `src/css-extractor.ts`     | **New** — CSSOM-based CSS extraction logic                                                  |
| `src/types.ts`             | Added `CSSParameters` interface and `css` field to `Parameters` and `CodeUpdatePayload`     |
| `src/withHTML.ts`          | Calls `extractCSS()` when enabled, formats CSS with Prettier, includes CSS in channel event |
| `src/components/Panel.tsx` | Tab bar UI, view mode state, combined output, language-aware syntax highlighting            |
| `.storybook/preview.ts`    | Enabled CSS extraction globally for dev/demo stories                                        |
| `.gitignore`               | Minor additions                                                                             |

### How to test

1. `pnpm install && pnpm start`
2. Open http://localhost:6006
3. Navigate to any story (e.g. Example/Button)
4. Open the **HTML** panel — you should see **HTML / CSS / COMBINED** tabs
5. Click **CSS** to see only the extracted CSS rules
6. Click **COMBINED** to see the self-contained `<style>` + HTML snippet
7. Use the copy button to verify the output works standalone
