### PR TITLE
feat: add docs source toggle for html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Storybook Addon HTML
 
-This addon for Storybook adds a panel tab that displays the rendered HTML for each story.
+This addon for Storybook adds a panel tab that displays the rendered HTML for each story. It also adds a `Docs source` toggle so Docs/Autodocs can show either the normal framework source or the captured rendered HTML.
 
 ![Animated preview](https://raw.githubusercontent.com/whitespace-se/storybook-addon-html/master/image.gif)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const ADDON_ID = 'storybook/html';
 export const PANEL_ID = `${ADDON_ID}/panel`;
 export const PARAM_KEY = 'html';
+export const DOCS_SOURCE_MODE_GLOBAL = 'htmlSourceMode';
 
 export const EVENTS = {
   CODE_UPDATE: `${ADDON_ID}/codeUpdate`,

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -9,7 +9,8 @@
  * https://storybook.js.org/docs/react/writing-stories/decorators
  */
 import type { ProjectAnnotations, Renderer } from 'storybook/internal/types';
-import { withHTML } from './withHTML';
+import { DOCS_SOURCE_MODE_GLOBAL } from './constants';
+import { transformDocsSource, withHTML } from './withHTML';
 
 /**
  * Note: if you want to use JSX in this file, rename it to `preview.tsx`
@@ -18,6 +19,30 @@ import { withHTML } from './withHTML';
 
 const preview: ProjectAnnotations<Renderer> = {
   decorators: [withHTML],
+  parameters: {
+    docs: {
+      source: {
+        transform: transformDocsSource,
+      },
+    },
+  },
+  initialGlobals: {
+    [DOCS_SOURCE_MODE_GLOBAL]: 'code',
+  },
+  globalTypes: {
+    [DOCS_SOURCE_MODE_GLOBAL]: {
+      name: 'Docs source',
+      description: 'Choose which source snippet Docs shows',
+      toolbar: {
+        icon: 'markup',
+        dynamicTitle: true,
+        items: [
+          { value: 'code', title: 'Code' },
+          { value: 'html', title: 'HTML' },
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,19 @@ export interface Parameters {
   transform?: (code: string) => string;
 }
 
+export type SourceMode = 'code' | 'html';
+
+export type StoryArgs = Record<string, unknown>;
+
 export interface CodeUpdatePayload {
   code: string;
   options: Parameters;
+}
+
+export interface DocsSnippetPayload {
+  id: string;
+  args?: StoryArgs;
+  source?: string | null;
+  format?: boolean | 'dedent';
+  sourceMode?: SourceMode;
 }

--- a/src/withHTML.ts
+++ b/src/withHTML.ts
@@ -1,26 +1,91 @@
-import { useChannel, useEffect } from 'storybook/preview-api';
+import { useChannel, useEffect, useGlobals, useRef } from 'storybook/preview-api';
+import { SNIPPET_RENDERED } from 'storybook/internal/docs-tools';
 import type { DecoratorFunction } from 'storybook/internal/types';
 import { format as formatWithPrettier } from 'prettier/standalone';
 import htmlPlugin from 'prettier/plugins/html';
-import { EVENTS } from './constants';
-import type { Parameters } from './types';
+import { DOCS_SOURCE_MODE_GLOBAL, EVENTS } from './constants';
+import type { DocsSnippetPayload, Parameters, SourceMode, StoryArgs } from './types';
 
 const DEFAULT_ROOT_SELECTOR = '#storybook-root, #root';
+const htmlSources = new Map<string, string>();
+const frameworkSources = new Map<string, DocsSnippetPayload>();
+// We use a module-level variable rather than reading storyContext.globals inside
+// transformDocsSource because: (1) the Source block doesn't subscribe to
+// GLOBALS_UPDATED — it only re-renders when SNIPPET_RENDERED fires, so globals
+// on the storyContext may be stale between a toggle and the next snippet emit;
+// (2) when no story is resolved, storyContext is {} with no globals at all.
+// The decorator sets this synchronously on every render, so it's always current.
+let currentSourceMode: SourceMode = 'code';
 
-function getRootElement(canvas: ParentNode | undefined, rootSelector: string) {
+function getSourceMode(globals: Record<string, unknown> | undefined): SourceMode {
+  return globals?.[DOCS_SOURCE_MODE_GLOBAL] === 'html' ? 'html' : 'code';
+}
+
+function getStoryArgs(context: { args: StoryArgs; unmappedArgs?: StoryArgs }) {
+  return context.unmappedArgs || context.args;
+}
+
+function getSnippetKey({ args, format, id, source, sourceMode }: DocsSnippetPayload) {
+  return JSON.stringify({
+    args,
+    format,
+    id,
+    source,
+    sourceMode,
+  });
+}
+
+export function transformDocsSource(code: string, storyContext: { id?: string; globals?: Record<string, unknown> }) {
+  if (!storyContext.id || currentSourceMode !== 'html') {
+    return code;
+  }
+
+  return htmlSources.get(storyContext.id) ?? code;
+}
+
+function getStoryRoot(root: ParentNode | Document, storyId: string) {
+  if (typeof root.querySelector !== 'function') {
+    return undefined;
+  }
+
+  const escapedId = CSS.escape(`story--${storyId}`);
+  const exactStoryRoot = root.querySelector(`[data-story-block="true"]#${escapedId}`);
+  if (exactStoryRoot instanceof Element) {
+    return exactStoryRoot;
+  }
+
+  const storyRoot = root.querySelector(`[data-story-block="true"][id^="${escapedId}"]`);
+  return storyRoot instanceof Element ? storyRoot : undefined;
+}
+
+function getRootElement(canvas: ParentNode | undefined, rootSelector: string, storyId: string) {
   if (typeof (canvas as ParentNode | undefined)?.querySelector === 'function') {
     const root = canvas?.querySelector(rootSelector);
-    if (root) {
+    if (root instanceof Element && root.innerHTML.trim() !== '') {
       return root;
     }
+
+    const storyRoot =
+      canvas instanceof Element && canvas.matches('[data-story-block="true"]')
+        ? canvas
+        : canvas?.querySelector('[data-story-block="true"]');
+
+    if (storyRoot instanceof Element) {
+      return storyRoot;
+    }
+  }
+
+  const storyRoot = getStoryRoot(document, storyId);
+  if (storyRoot) {
+    return storyRoot;
   }
 
   return document.querySelector(rootSelector);
 }
 
-function getCode(canvas: ParentNode | undefined, parameters: Parameters) {
+function getCode(canvas: ParentNode | undefined, parameters: Parameters, storyId: string) {
   const rootSelector = parameters.root || DEFAULT_ROOT_SELECTOR;
-  const root = getRootElement(canvas, rootSelector);
+  const root = getRootElement(canvas, rootSelector, storyId);
   let code = root ? root.innerHTML : `${rootSelector} not found.`;
   const { removeEmptyComments, removeComments, transform } = parameters;
 
@@ -47,6 +112,21 @@ function getCode(canvas: ParentNode | undefined, parameters: Parameters) {
   return code;
 }
 
+async function getCodeWhenReady(canvas: ParentNode | undefined, parameters: Parameters, storyId: string) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const code = getCode(canvas, parameters, storyId);
+    if (code.trim() !== '') {
+      return code;
+    }
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 100);
+    });
+  }
+
+  return getCode(canvas, parameters, storyId);
+}
+
 async function prettifyHtml(code: string) {
   try {
     return await formatWithPrettier(code, {
@@ -61,18 +141,67 @@ async function prettifyHtml(code: string) {
 }
 
 export const withHTML: DecoratorFunction = (storyFn, context) => {
-  const emit = useChannel({});
-  const parameters = (context.parameters?.html as Parameters | undefined) || {};
+  const [globals] = useGlobals();
+  const lastSnippetKey = useRef<string>('');
+  const emit = useChannel({
+    [SNIPPET_RENDERED]: (payload: DocsSnippetPayload) => {
+      if (!payload.id || payload.sourceMode) {
+        return;
+      }
 
+      frameworkSources.set(payload.id, payload);
+    },
+  });
+  const parameters = (context.parameters?.html as Parameters | undefined) || {};
+  currentSourceMode = getSourceMode(globals);
+
+  // No dependency array: must re-run on every render to pick up globals and args changes.
   useEffect(() => {
     const timer = window.setTimeout(async () => {
-      const code = getCode(context.canvasElement as ParentNode | undefined, parameters);
+      const storyArgs = getStoryArgs(context);
+      const code = await getCodeWhenReady(context.canvasElement as ParentNode | undefined, parameters, context.id);
       const prettifiedCode = await prettifyHtml(code);
+      const sourceMode = currentSourceMode;
+      const frameworkSource = frameworkSources.get(context.id);
+
+      htmlSources.set(context.id, prettifiedCode);
       emit(EVENTS.CODE_UPDATE, { code: prettifiedCode, options: parameters });
+
+      const docsSnippet =
+        sourceMode === 'html'
+          ? {
+              id: context.id,
+              args: storyArgs,
+              source: prettifiedCode,
+              format: false,
+              sourceMode,
+            }
+          : frameworkSource
+            ? {
+                ...frameworkSource,
+                args: frameworkSource.args || storyArgs,
+                sourceMode,
+              }
+            : undefined;
+
+      if (!docsSnippet) {
+        lastSnippetKey.current = '';
+        return;
+      }
+
+      const nextSnippetKey = getSnippetKey(docsSnippet);
+      if (nextSnippetKey === lastSnippetKey.current) {
+        return;
+      }
+
+      lastSnippetKey.current = nextSnippetKey;
+      emit(SNIPPET_RENDERED, docsSnippet);
     }, 0);
 
     return () => {
       window.clearTimeout(timer);
+      htmlSources.delete(context.id);
+      frameworkSources.delete(context.id);
     };
   });
 


### PR DESCRIPTION
Adds a Docs source-mode toggle to the addon so Storybook Docs/Autodocs can switch between the default framework source and captured rendered HTML, while keeping the existing HTML panel behavior and preserving normal source display as the default.